### PR TITLE
docs(v2): add Stage 3 V2 docs (architecture + migration plan)

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,78 @@
+# api_key_manager — API
+
+## Electron Renderer Surface (`window.electronAPI`)
+Exposed in **electron/preload.ts**, typed in **src/types/index.ts**.
+
+### keychain
+- `setPassword(service, account, password)` → `{ success, error? }`
+- `getPassword(service, account)` → `{ success, password?: string|null, error? }`
+- `deletePassword(service, account)` → `{ success, deleted?: boolean, error? }`
+- `findCredentials(service)` → `{ success, credentials?: Array<{ account:string; password:string }>, error? }`
+
+### file
+- `showOpenDialog()` → `{ canceled, filePaths? }`
+- `showSaveDialog(defaultPath?)` → `{ canceled, filePath? }`
+- `readFile(filePath)` → `{ success, content?, error? }`
+- `writeFile(filePath, content)` → `{ success, error? }`
+
+### fs helpers
+- `saveFile({ content, defaultPath? })` → `FileOperationResult`
+- `openFile({ filters? })` → `FileOperationResult`
+
+### system
+- `openExternal(url)` → `{ success, error? }`
+
+### clipboard
+- `writeText(text)` → `{ success, error? }`
+
+Example:
+```ts
+await window.electronAPI.keychain.setPassword(
+  'api-key-manager',  // service
+  'openai',           // account
+  'sk-...'            // password
+);
+```
+
+---
+
+## Web-only Fallbacks (no Electron)
+When `window.electronAPI` is **undefined** (`src/stores/apiKeyStore.ts`):
+
+| Capability | Desktop (Electron) | Web fallback |
+|------------|-------------------|--------------|
+| Store key  | Keychain via IPC  | `localStorage.setItem('apikey_'+service, value)` |
+| Read key   | Keychain          | `localStorage.getItem('apikey_'+service)` |
+| File I/O   | Native dialogs / fs | DOM File input + `Blob` download |
+| Clipboard  | `electron.clipboard` | `navigator.clipboard.writeText` |
+
+---
+
+## Zustand Stores
+
+### useApiKeyStore (src/stores/apiKeyStore.ts)
+| Method | Purpose |
+|--------|---------|
+| `setKey(service, value)` | Persist key (Keychain or localStorage) |
+| `getKey(service)` | `string \| null` |
+| `deleteKey(service)` | Remove key |
+| `testKey(service)` | Validate key against service endpoint |
+| `importFromEnv(content)` | Bulk import from `.env` text |
+| `exportToEnv()` | Return `.env` formatted string |
+| `loadKeys()` / `clearAllKeys()` | Sync or purge state |
+
+### useUiStore (src/stores/uiStore.ts)
+Navigation, notifications, filters:
+`setActiveTab`, `showSuccess|Error|Warning|Info`, `setSearchQuery`, `setSelectedCategory`, `setSelectedService`.
+
+---
+
+## Service Catalog
+`src/data/apiServices.ts` holds 13+ predefined service configs (id, testEndpoint, headers).  
+`useApiKeyStore.testKey()` consumes these definitions to perform live validation.
+
+---
+
+## Notes
+Electron main automatically prefixes every Keychain entry with `API-Key-Manager-<service>` (see `electron/main.ts`).  
+Therefore, when the renderer passes plain service IDs such as `openai`, the stored Keychain item will be named `API-Key-Manager-openai`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,61 @@
+# api_key_manager — ARCHITECTURE
+
+## Overview
+Dual-target app:
+- Desktop: Electron main process + React renderer (Keychain via `keytar`)
+- Web: React app build (no Electron APIs)
+
+## Key Paths
+- Electron main: `electron/main.ts`
+- Electron preload (exposed API): `electron/preload.ts`
+- Renderer entry: `src/main.tsx`
+- App UI component: `api-key-manager.tsx`
+- Vite configs: `vite.config.ts` (desktop), `vite.config.web.ts` (web)
+- Packaging: electron-builder config in `package.json` → `build` section
+- Web deploy: `vercel.json`
+- HTML shell (CSP): `index.html`
+
+## Dev & Ports
+- Vite dev server: `http://localhost:5173` (see `vite.config.ts`)
+- Electron dev waits for Vite: `scripts.dev:electron` uses `wait-on http://localhost:5173`
+- Electron main loads:
+  - dev: `loadURL('http://localhost:5173')`
+  - prod: `loadFile('../dist/index.html')`
+
+## Electron Main (security & windows)
+- Window opts: `contextIsolation: true`, `webSecurity: true`, `allowRunningInsecureContent: false` (in `electron/main.ts`)
+- Deny new windows: `web-contents-created` + `setWindowOpenHandler(() => ({action:'deny'}))`
+- macOS build focus: electron-builder `mac` target (DMG), hardenedRuntime and entitlements
+
+## IPC Surface (from `electron/main.ts` / bridged in `electron/preload.ts`)
+- `keychain:setPassword(service, account, password)` → keytar.setPassword
+- `keychain:getPassword(service, account)` → keytar.getPassword
+- `keychain:deletePassword(service, account)` → keytar.deletePassword
+- `keychain:findCredentials(service)` → keytar.findCredentials
+- `file:showOpenDialog()` / `file:showSaveDialog(defaultPath?)` / `file:readFile(path)` / `file:writeFile(path, content)`
+- `system:openExternal(url)`
+- `clipboard:writeText(text)`
+
+These are exposed to renderer via `window.electronAPI` in `preload.ts`.
+
+## Renderer (React)
+- Entry: `src/main.tsx`
+- App logic/UI: `api-key-manager.tsx`, Zustand stores under `src/stores/*`, service config in `src/data/apiServices.ts`
+- Web fallback: when `window.electronAPI` is undefined, storage uses `localStorage` (see `src/stores/apiKeyStore.ts`)
+
+## Builds
+- Desktop build: `npm run build` → `vite build` (frontend) + `tsc -p electron` → `dist/`
+- Desktop package: `npm run dist` / `npm run dist:mac` (electron-builder) → `release/`
+- Web build: `npm run build:web` → `dist-web/` (see `vite.config.web.ts` & `vercel.json`)
+
+## Security hardening present in code
+- CSP meta in `index.html`
+- Electron context isolation + limited IPC
+- macOS hardened runtime/entitlements in `assets/entitlements.mac.plist`
+
+## Data flow
+
+• **Desktop mode:** React renderer ➜ `window.electronAPI` ➜ IPC bridge in `preload.ts` ➜ Electron **main** handlers ➜ native modules (`keytar`, `fs`, Electron system APIs).  
+• **Key storage path:** Renderer call `keychain.setPassword` ➜ IPC ➜ `keytar` writes secret to macOS Keychain.  
+• **File ops:** Renderer invokes `file:readFile`/`file:writeFile` ➜ main reads/writes via Node `fs`.  
+• **Web mode fallback:** When `window.electronAPI` is undefined, renderer stores keys in **localStorage** and uses standard Web APIs for file download / upload and clipboard access.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,132 @@
+# api_key_manager — RUNBOOK
+
+_Last updated: 2025-09-13_
+
+---
+
+## 1  Processes & Scripts
+
+| Intent            | Script | Notes |
+|-------------------|--------|-------|
+| **Desktop dev**   | `npm run dev` | Runs Vite on port 5173, then launches Electron after `wait-on` succeeds |
+| **Web dev**       | `npm run dev:web` | Pure browser build (same port 5173) |
+| **Desktop build** | `npm run build` | Creates `dist/` (renderer) + compiles Electron (`electron/*.ts`) |
+| **Web build**     | `npm run build:web` | Creates `dist-web/` for CDN/Vercel |
+| **Package**       | `npm run dist` / `npm run dist:mac` | Electron-builder → `release/` dmg/pkg |
+| **Lint / Type-check** | `npm run check` | ESLint + TypeScript |
+
+---
+
+## 2  Configuration Knobs
+
+| Area | Location | Default |
+|------|----------|---------|
+| Dev server port | `vite.config.ts` / `vite.config.web.ts` | **5173** |
+| CSP header      | `<meta http-equiv="Content-Security-Policy">` in `index.html` | `default-src 'self'` |
+| Electron entitlements | `assets/entitlements.mac.plist` | Hardened runtime, keychain-sharing |
+| Builder targets | `package.json → build` | `mac`, `dmg`, `dir` |
+| Log level       | `LOG_LEVEL` env var (optional) | `info` |
+
+Environment variables recognised at runtime:
+
+* `NODE_ENV` – `development` / `production` (used by Vite/Electron)
+* `ELECTRON_DISABLE_SECURITY_WARNINGS=1` (optional during dev)
+
+---
+
+## 3  Start / Stop Procedures
+
+Desktop development
+```bash
+npm run dev
+# ↳ Terminates with Ctrl-C (stops both Vite & Electron)
+```
+
+Web development
+```bash
+npm run dev:web   # Ctrl-C to stop
+```
+
+Production desktop
+```bash
+npm run build
+npm run dist:mac    # produces DMG
+open release/API\ Key\ Manager-*.dmg
+```
+
+---
+
+## 4  Health Checks
+
+### Desktop
+1. Application window appears with Manage/Test/Parser tabs.
+2. Create a dummy key → should store in macOS Keychain (verify via Keychain Access).
+3. “Test All” returns mixed pass/fail results but network calls succeed (view DevTools > Network).
+
+### Web
+1. Navigate to http://localhost:5173 → UI renders without Electron warnings.
+2. Add a key, refresh page – key persists via `localStorage`.
+
+---
+
+## 5  Logs & Diagnostics
+
+| Source | How to view |
+|--------|-------------|
+| Renderer | DevTools → Console / Network |
+| Electron main | Terminal running `npm run dev` (stdout / stderr) |
+| Build pipeline | `dist/` and `release/` folders + electron-builder output |
+| Keychain failures | macOS Console.app → “securityd” or `log stream --info --predicate 'subsystem == "com.apple.security"'` |
+
+Diagnostic tips:
+
+```
+# Check port
+lsof -i :5173
+
+# Validate CSP
+grep Content-Security-Policy dist/index.html
+```
+
+---
+
+## 6  Common Failures & Remedies
+
+| Symptom | Probable Cause | Resolution |
+|---------|----------------|------------|
+| `wait-on http://localhost:5173` hangs | Port already in use | Kill offending process or change port in `vite.config.ts` |
+| `ipcRenderer.invoke('keychain:setPassword', …)` returns `{success:false}` | Keychain access denied | Grant access when macOS prompts, or sign/notarize app for prod |
+| `window.electronAPI` is `undefined` | Running web build inside browser | Expected; app falls back to `localStorage` |
+| “blocked by CSP” console errors | Inline script / eval | Refactor to module import; adjust CSP if absolutely required |
+
+---
+
+## 7  Release Procedure (Desktop)
+
+1. `git pull --ff-only && npm ci`
+2. `npm run check` – ensure no lint/type errors.
+3. `npm run build`
+4. `npm run dist:mac`
+5. Codesign & notarize (CI handles if `APPLE_ID` creds present).
+6. Upload `release/API Key Manager-<ver>.dmg` to distribution channel.
+7. Tag commit: `git tag v<ver> && git push --tags`
+
+---
+
+## 8  Rollback
+
+* **Desktop:** Re-install previous DMG from `release/` archive or distribute prior tag artifact.
+* **Web:** Redeploy previous `dist-web/` build (e.g., select earlier Vercel deployment).
+
+---
+
+## 9  Data Considerations
+
+| Platform | Storage path | Backup strategy |
+|----------|--------------|-----------------|
+| Desktop  | macOS Keychain item `api-key-manager` | Managed by macOS (encrypted, backed up with iCloud Keychain) |
+| Web      | `window.localStorage` keys `apikey_<service>` | User-side only; no server copy. Clearing site data deletes secrets |
+
+---
+
+_End of runbook_

--- a/SECURITY_NOTES.md
+++ b/SECURITY_NOTES.md
@@ -1,0 +1,46 @@
+# api_key_manager — SECURITY NOTES
+
+## Trust boundaries
+- **Renderer (React)** is unprivileged; all privileged work is routed through `window.electronAPI` defined in `electron/preload.ts`.
+- **Main process** performs Keychain access, file I/O, clipboard writes, and `openExternal` calls.
+
+## Hardening present in code
+| Area | Setting / Source |
+|------|------------------|
+| Context isolation | `contextIsolation: true`, `nodeIntegration: false` (`electron/main.ts`) |
+| Web security flags | `webSecurity: true`, `allowRunningInsecureContent: false` |
+| Window creation | `setWindowOpenHandler(() => ({ action: 'deny' }))` prevents pop-ups |
+| CSP | `<meta http-equiv="Content-Security-Policy" ...>` in `index.html`<br>``default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https:;`` |
+| macOS hardening | Hardened runtime + entitlements in `assets/entitlements.mac.plist`; targets defined in `package.json → build.mac` |
+
+## Secrets & storage
+- **Desktop:** Secrets stored with `keytar` in macOS Keychain under service `API-Key-Manager-<service>`.
+- **Web:** When `window.electronAPI` is absent, secrets fall back to `localStorage` (`src/stores/apiKeyStore.ts`).
+
+## Network egress
+- Outbound `fetch` requests only inside key-test logic (`src/stores/apiKeyStore.ts`) targeting endpoints enumerated in `src/data/apiServices.ts`.
+- No telemetry or analytics libraries present.
+
+## IPC surface (attack surface)
+| Channel prefix | Purpose |
+|----------------|---------|
+| `keychain:*` | set/get/delete/find credentials |
+| `file:*` | open/save dialogs, read/write file |
+| `system:openExternal` | open URL in default browser |
+| `clipboard:writeText` | copy text to clipboard |
+
+No other IPC handlers are registered.
+
+## Operator checklist
+1. **Context isolation** – Open DevTools in renderer; `window.process` must be `undefined`.
+2. **CSP** – Inspect `<meta http-equiv="Content-Security-Policy">`; ensure no `unsafe-eval` or remote origins.
+3. **IPC audit** – `Object.keys(window.electronAPI)` should return only `keychain`, `file`, `system`, `clipboard`.
+4. **Keychain verification** – After saving a key, open Keychain Access; item name should start with `API-Key-Manager-`.
+5. **Entitlements** – Run `codesign -d --entitlements :- <App>` on packaged binary; confirm only declared entitlements are present.
+6. **Build flags** – In prod build, verify `NODE_ENV=production` and `process.env.ELECTRON_ENABLE_SECURITY_WARNINGS` is not disabled.
+
+## Recommendations
+- Keep CSP strict; avoid adding `unsafe-eval` or remote script sources.
+- Limit future IPC additions to minimal, well-typed surfaces.
+- Sign and notarize desktop builds; ship with hardened runtime and least-privilege entitlements.
+- Serve web build over HTTPS; consider encrypting values before `localStorage` if additional assurance is required.

--- a/SECURITY_NOTES.md
+++ b/SECURITY_NOTES.md
@@ -10,8 +10,10 @@
 | Context isolation | `contextIsolation: true`, `nodeIntegration: false` (`electron/main.ts`) |
 | Web security flags | `webSecurity: true`, `allowRunningInsecureContent: false` |
 | Window creation | `setWindowOpenHandler(() => ({ action: 'deny' }))` prevents pop-ups |
-| CSP | `<meta http-equiv="Content-Security-Policy" ...>` in `index.html`<br>``default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https:;`` |
+| CSP | `<meta http-equiv="Content-Security-Policy" ...>` in `index.html`<br>``default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self';`` |
 | macOS hardening | Hardened runtime + entitlements in `assets/entitlements.mac.plist`; targets defined in `package.json → build.mac` |
+- Prefer CSP: `default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'` (tighten `connect-src` to explicit hosts when remote APIs are introduced).
+- Validate URLs passed to `system.openExternal` against an allowlist of `https:` origins; reject custom schemes.
 
 ## Secrets & storage
 - **Desktop:** Secrets stored with `keytar` in macOS Keychain under service `API-Key-Manager-<service>`.

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,58 @@
+# api_key_manager — SETUP
+
+## Prerequisites
+- Node.js ≥ 18 (npm comes bundled)
+- macOS (required only for building the Electron desktop version that integrates with Keychain)
+
+## Install
+```bash
+cd /Users/arkadiuszfudali/Git/api_key_manager
+npm install          # installs root + electron deps
+```
+
+## Development
+
+Desktop (Electron + Vite, hot-reload):
+```bash
+npm run dev
+# → concurrently:
+#    1) vite  → http://localhost:5173
+#    2) wait-on http://localhost:5173 && electron .
+```
+
+Web-only dev preview:
+```bash
+npm run dev:web      # vite --config vite.config.web.ts (port 5173)
+```
+
+Frontend only (no Electron, desktop assets build untouched):
+```bash
+npm run dev:vite     # vite (desktop config) on port 5173
+```
+
+## Build
+
+Desktop bundle (frontend + Electron):
+```bash
+npm run build        # => vite build (dist/) + tsc -p electron (dist/)
+```
+
+Web bundle:
+```bash
+npm run build:web    # outputs dist-web/ (web-only build)
+```
+
+## Distribute (desktop)
+
+Create signed macOS disk-image:
+```bash
+npm run dist         # cross-platform targets defined in package.json "build"
+npm run dist:mac     # mac-only DMG build
+```
+Artifacts are placed in `release/`.
+
+## Notes
+- Dev server & Electron dev target both expect **http://localhost:5173** (see `vite.config*.ts`).
+- In production the Electron main process loads `dist/index.html`; in dev it loads the Vite URL.
+- Web deployment template is configured in `vercel.json` (`build:web` + `dist-web/`).
+- Use `npm run check` or `npm run lint` before committing to run TypeScript and ESLint.

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,3 +1,4 @@
+> Note: Currently scripts use npm. V2 will migrate to pnpm workspaces.
 # api_key_manager — SETUP
 
 ## Prerequisites
@@ -6,7 +7,7 @@
 
 ## Install
 ```bash
-cd /Users/arkadiuszfudali/Git/api_key_manager
+cd api_key_manager
 npm install          # installs root + electron deps
 ```
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -1,0 +1,40 @@
+# api_key_manager — TESTS
+
+## Automated checks
+```bash
+npm run check   # tsc --noEmit && eslint
+```
+
+## Smoke tests — Desktop (Electron)
+1. Start dev: `npm run dev`
+2. Add a key for `openai`.
+3. Verify stored via Keychain: open **Keychain Access** and search `API-Key-Manager-openai`.
+4. Click **“Test All”**. Confirm network calls hit endpoints in `src/data/apiServices.ts` and that responses update `isValid` in store (`src/stores/apiKeyStore.ts`).
+5. Export `.env`; ensure file is written via IPC (`file:writeFile`).
+
+## Smoke tests — Web
+1. Start web: `npm run dev:web`
+2. Add a key for `openai`.
+3. Refresh page; key persists (stored in `localStorage`).
+4. Import `.env`; ensure UI reflects imported keys.
+
+## IPC contract checks
+Open DevTools console in **desktop** build:
+```js
+await window.electronAPI.keychain.setPassword('api-key-manager','openai','sk-123');
+await window.electronAPI.keychain.getPassword('api-key-manager','openai');
+await window.electronAPI.file.writeFile('/tmp/keys.env', 'OPENAI_API_KEY=sk-123');
+await window.electronAPI.system.openExternal('https://openai.com');
+```
+All calls should resolve with `{ success: true, ... }`.
+
+## CSP check (web & desktop)
+- Inspect `index.html` for the `<meta http-equiv="Content-Security-Policy">` tag.
+- Ensure no console errors about blocked inline/eval scripts during normal usage.
+
+## Build & package
+```bash
+npm run build        # dist/ (renderer + electron)
+npm run dist:mac     # release/ DMG
+```
+Open the packaged app and repeat the desktop smoke tests.

--- a/V2_ARCHITECTURE.md
+++ b/V2_ARCHITECTURE.md
@@ -75,7 +75,7 @@ Scripts defined in root `package.json`.
 ## 9. Security Notes  
 - **Context Isolation** enabled; `nodeIntegration` disabled.  
 - Preload whitelist only exposes safe IPC; validate inputs in **main**.  
-- Credentials saved with **keytar** (desktop) or `IndexedDB` encrypted mock (web).  
+- Credentials saved with **keytar** (desktop). Web fallback is current `localStorage`; Target (V2): encrypted IndexedDB.
 - Secrets never persist in Zustand; reset on app quit / browser tab close.  
 - Gitleaks & Semgrep run in CI (warn-only initially).
 

--- a/V2_ARCHITECTURE.md
+++ b/V2_ARCHITECTURE.md
@@ -1,0 +1,87 @@
+# api_key_manager — V2 ARCHITECTURE
+
+## 1. Targets & Use-cases  
+| Target | Purpose | Output |
+|--------|---------|--------|
+| **Web** | Browser-only password manager (dev/demo) | `dist/` bundle served by any static host |
+| **Desktop** | Secure credential vault using OS keychain | macOS `.dmg`, Windows `.exe` via `electron-builder` |
+
+## 2. Tech Stack  
+• Node 20 + pnpm workspaces  
+• Electron 30 (Chromium 124) — `electron/` folder  
+• React 18 + Vite — `src/` (renderer + web build)  
+• Zustand — state management (`src/store/`)  
+• TypeScript everywhere (strict)  
+
+## 3. Directory Layout (key paths)  
+```
+electron/
+  ├─ main.ts        # Main-process: windows, menu, IPC handlers
+  └─ preload.ts     # Context-isolated bridge → window.electronAPI
+src/
+  ├─ index.tsx      # React root
+  ├─ store/         # Zustand slices (ui, credentials…)
+  ├─ services/      # HTTP & keychain adapters
+  └─ components/    # UI
+vite.config.ts      # Common config for web & renderer
+package.json        # root scripts (pnpm monorepo)
+```
+
+## 4. Runtime Flow  
+1. **Desktop launch**  
+   - `electron .` → `main.ts` creates `BrowserWindow` with `preload.js`  
+   - Renderer bootstraps React app (`index.tsx`).  
+2. **Web launch**  
+   - `pnpm web:dev` → Vite serves React at `http://localhost:5173`.  
+3. **IPC contract (preload.ts)**  
+   - Exposes minimal, typed API on `window.electronAPI`  
+   - Channels:  
+     • `keychain.*` → wrap **keytar** ops  
+     • `file.*` → open/save dialogs + fs  
+     • `system.openExternal` → shell links  
+     • `clipboard.writeText` → secure copy  
+
+## 5. State & Services  
+- **Zustand stores** keep transient UI state; sensitive data cleared on window blur.  
+- `src/services/keychain.ts` calls `electronAPI.keychain.*` (desktop) or falls back to `localStorage` mock (web).  
+- `src/services/config.ts` centralises base URL, feature flags, version.
+
+## 6. Configuration & Environment  
+| File | Variable | Note |
+|------|----------|------|
+| `.env.example` | `VITE_API_BASE` | optional remote sync service |
+| `src/services/config.ts` | `APP_MODE` | `'web' | 'desktop'` inferred at runtime |
+
+No secrets committed; desktop build relies on OS keychain.
+
+## 7. Build & Dev Commands  
+| Task | Command |
+|------|---------|
+| Web dev | `pnpm web:dev` |
+| Web prod build | `pnpm web:build` |
+| Electron dev | `pnpm electron:dev` |
+| Electron package (mac) | `pnpm electron:pack` |
+| Lint & type-check | `pnpm lint && pnpm typecheck` |
+
+Scripts defined in root `package.json`.
+
+## 8. Continuous Integration (Stage 4)  
+`.github/workflows/node.yml` (Node 20):  
+1. Install → `pnpm install --frozen-lockfile`.  
+2. Run `lint`, `typecheck`, `test:web`.  
+3. Cache `.pnpm-store`.  
+4. Electron packaging job optional & macOS-only (manual trigger).
+
+## 9. Security Notes  
+- **Context Isolation** enabled; `nodeIntegration` disabled.  
+- Preload whitelist only exposes safe IPC; validate inputs in **main**.  
+- Credentials saved with **keytar** (desktop) or `IndexedDB` encrypted mock (web).  
+- Secrets never persist in Zustand; reset on app quit / browser tab close.  
+- Gitleaks & Semgrep run in CI (warn-only initially).
+
+## 10. Next Steps (Stage 4)  
+- Add `.env.example`, `.editorconfig`, pre-commit hooks.  
+- Write unit tests for IPC wrappers (`vitest + @testing-library/react`).  
+- Draft Electron packaging workflow (`electron-builder --publish=never`).  
+
+_This document defines the actionable V2 architecture for api_key_manager and will guide Stage 4 container & CI scaffolding._

--- a/V2_MIGRATION_PLAN.md
+++ b/V2_MIGRATION_PLAN.md
@@ -1,0 +1,144 @@
+# api_key_manager — V2 MIGRATION PLAN  
+
+Brings **api_key_manager** in line with the portfolio-wide V2 standards (Node 20, pnpm, GitHub Actions, dual-target build, hardened IPC, security gates).
+
+---
+
+## 0. Prerequisites  
+
+| Item | Notes |
+|------|-------|
+| Node 20 | `nvm install 20 && nvm use 20` |
+| pnpm ≥ 8 | `corepack enable && corepack prepare pnpm@latest --activate` |
+| macOS codesign (desktop) | Xcode CLI + Developer ID (optional) |
+| GitHub secrets | `GH_TOKEN` (electron-builder), _optional_: `APPLE_ID`, `APPLE_ID_PASS` |
+
+---
+
+## 1. Baseline & Environment  
+
+| Task | Command / File | ✓ |
+|------|----------------|---|
+| Declare engines | `"engines": { \"node\": \">=20\" }` in `package.json` | [ ] |
+| Add **.nvmrc** → `20` | `echo 20 > .nvmrc` | [ ] |
+| Add **.editorconfig** & update **.gitignore** | reuse portfolio template | [ ] |
+| Create **.env.example** | vars: `VITE_APP_MODE`, `VITE_API_BASE` | [ ] |
+| Pin pnpm workspace versions | `pnpm m up -L` | [ ] |
+
+---
+
+## 2. Security & IPC Hardening  
+
+1. **Renderer Isolation** – ensure:  
+   ```ts
+   new BrowserWindow({
+     webPreferences: { contextIsolation: true, nodeIntegration: false }
+   })
+   ```
+2. **Typed preload** (already OK).  
+3. **Validate IPC** in `main.ts` – use `zod` schemas or manual checks.  
+4. **Keychain usage**  
+   - Desktop: `keytar` for all persistence.  
+   - Web fallback: AES-encrypted `IndexedDB`.  
+5. **Transient data hygiene** – clear Zustand stores on `blur` / `lock`.  
+
+Checklist  
+
+- [ ] All `ipcMain.handle` inputs validated  
+- [ ] No untyped `ipcRenderer.send` from renderer  
+- [ ] Keytar errors bubbled to UI with safe message  
+
+---
+
+## 3. Build & Scripts  
+
+| Script | Purpose |
+|--------|---------|
+| `web:dev` | `vite --mode web` |
+| `web:build` | `vite build --mode web` |
+| `electron:dev` | `electron .` (uses Vite dev server) |
+| `electron:pack` | `electron-builder --mac --dir` (no publish) |
+| `lint`, `typecheck`, `test:web` | ESLint, `tsc --noEmit`, Vitest |
+
+Update `package.json` root & workspace `scripts`.
+
+---
+
+## 4. CI (GitHub Actions)  
+
+`.github/workflows/node.yml`
+
+```yaml
+name: Node CI
+on: [push, pull_request]
+
+jobs:
+  build-test-web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20, cache: 'pnpm' }
+      - run: corepack enable
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint && pnpm typecheck && pnpm test:web
+      - run: gitleaks detect --no-git -v || true
+      - run: semgrep ci --severity=ERROR || true
+
+  package-macos:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20, cache: 'pnpm' }
+      - run: corepack enable
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm electron:pack
+```
+
+CI success criteria  
+
+- Web job mandatory, passes on every PR.  
+- macOS packaging job manual (does not block).  
+- Security jobs annotate only.
+
+---
+
+## 5. Quality Assurance  
+
+| Scope | Tool | Target |
+|-------|------|--------|
+| Unit tests | Vitest | `electronAPI` wrappers, Zustand stores |
+| Desktop E2E (optional) | Playwright + `@playwright/test` | smoke flow (add / copy credential) |
+| Lint | ESLint + Prettier | all TS |
+| Types | `tsc --noEmit` | strict |
+
+Checklist  
+
+- [ ] ≥ 80 % unit test coverage web target  
+- [ ] Playwright smoke scenario documented (even if not in CI)  
+
+---
+
+## 6. Timeline & Owners  
+
+| Week | Deliverable | Owner |
+|------|-------------|-------|
+| 1 | Section 1 tasks, scripts updated, engines pinned | dev |
+| 2 | IPC validation, keytar integration finalised | dev |
+| 3 | CI workflow merged & green | dev + reviewer |
+| 4 | Desktop pack job verified locally & via CI | dev |
+| 5 | QA suite reaches coverage target | dev |
+
+---
+
+## 7. Success Criteria  
+
+- Web **and** desktop builds succeed (`pnpm web:build`, `pnpm electron:pack`).  
+- GitHub Actions green on every PR; security jobs annotate but don’t fail.  
+- No secrets in repository; **.env.example** present & up to date.  
+- All IPC channels validated and covered by tests.  
+- Keychain operations function on macOS; web fallback encrypts data.  
+
+_When all boxes are ticked, api_key_manager is V2-compliant and ready for Stage 5 integration._


### PR DESCRIPTION
This Droid-assisted PR adds Stage 3 documentation for api_key_manager:

- V2_ARCHITECTURE.md
- V2_MIGRATION_PLAN.md

Also includes Stage 2 operational docs.

Validation:
- Docs only; no runtime changes

Next: Stage 4 scaffold (web Node CI, optional electron packaging workflow, pre-commit) in a follow-up PR.

---
**Factory Session:** https://app.factory.ai/sessions/w42wDJmkwhE2l1EzT9L6 (created by makaronz@gmail.com)




<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds comprehensive Stage 3 V2 documentation for api_key_manager, including architecture, migration plans, and operational procedures.
> 
>   - **Documentation**:
>     - Adds `V2_ARCHITECTURE.md` and `V2_MIGRATION_PLAN.md` for api_key_manager.
>     - Includes operational docs: `API.md`, `ARCHITECTURE.md`, `RUNBOOK.md`, `SECURITY_NOTES.md`, `SETUP.md`, `TESTS.md`.
>   - **Content**:
>     - `V2_ARCHITECTURE.md` outlines dual-target architecture, tech stack, and runtime flow.
>     - `V2_MIGRATION_PLAN.md` details steps for migrating to V2 standards, including security and CI updates.
>     - `API.md` describes Electron and web API surfaces, Zustand stores, and service catalog.
>     - `ARCHITECTURE.md` explains key paths, dev setup, and security hardening.
>     - `RUNBOOK.md` provides scripts, configuration, and release procedures.
>     - `SECURITY_NOTES.md` covers trust boundaries, hardening, and operator checklist.
>     - `SETUP.md` and `TESTS.md` guide installation, development, and testing processes.
>   - **Validation**:
>     - Documentation only; no runtime changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=makaronz%2Fapi_key_manager&utm_source=github&utm_medium=referral)<sup> for c5a993068acb51b91dadce66591851da315eb3f2. You can [customize](https://app.ellipsis.dev/makaronz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add Stage 3 V2 documentation for api_key_manager, introducing comprehensive docs across architecture, migration plan, security, setup, tests, runbook, and API references (ARCHITECTURE.md, V2_ARCHITECTURE.md, V2_MIGRATION_PLAN.md, SECURITY_NOTES.md, RUNBOOK.md, SETUP.md, TESTS.md, API.md).

### Why are these changes being made?

Document the Stage 3 V2 architecture and migration plan to align with portfolio-wide standards and prepare for Stage 4. The new docs capture design decisions, security considerations, and operational procedures to improve clarity for reviewers and future contributors.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Dokumentacja**
  - Dodano pełen zestaw dokumentów: API (renderer API i web fallback), ARCHITECTURE, RUNBOOK, SECURITY_NOTES, SETUP, TESTS, V2_ARCHITECTURE oraz V2_MIGRATION_PLAN.
  - Dokumenty opisują uruchomienie, architekturę desktop/web, IPC i powierzchnię bezpieczeństwa, procedury build/release, testy (smoke/CSP), oraz plan migracji do standardów V2 i CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->