### PR TITLE
Set up Cursor Cloud dev environment (web scope) + AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### What this project is
+API Key Manager is a **dual-platform** app (see `README.md`):
+- A **macOS desktop** build (Electron + `keytar` / macOS Keychain).
+- A **web** build (React + Vite, keys stored in `localStorage`).
+
+### Runnable scope in Cloud (Linux)
+Only the **web version** runs in this Linux Cloud environment. The Electron
+desktop build targets macOS only (it depends on the macOS Keychain via `keytar`),
+so `npm run dev` / `npm run dist:mac` are not runnable here. Use the web scripts.
+
+Standard commands are documented in `README.md` and `package.json` scripts. The
+web-relevant ones:
+- `npm run check` — TypeScript (`tsc --noEmit`) + ESLint. Works everywhere.
+- `npm run dev:web` — Vite dev server on `http://localhost:5173` (`strictPort`, so
+  free the port first if it's taken).
+- `npm run build:web` — production web build into `dist-web/`.
+
+### Non-obvious gotchas
+- **`NODE_ENV=production` is set in this environment.** Plain `npm install` therefore
+  **omits devDependencies** (vite, eslint, typescript, electron, etc.), leaving the
+  project unbuildable. Always install with `npm install --include=dev` (the update
+  script does this). This is the single most important setup detail.
+- The web store transparently falls back to `localStorage` when `window.electronAPI`
+  is absent (`src/stores/apiKeyStore.ts`), which is why the web app is fully
+  functional without Electron. Some UI actions that are Electron-only (copy to
+  clipboard, open external URL, save-to-file) call `window.electronAPI` directly and
+  will throw in the browser — the core add/edit/delete/search/persist flows do not.
+- `postcss.config.js` emits a harmless "module type not specified" warning during
+  Vite builds; it does not affect output.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up the development environment for this repo in Cursor Cloud (Linux) and documents durable, non-obvious setup guidance in a new `AGENTS.md`.

This repo is a **dual-platform** app: a macOS Electron desktop build (`keytar`/Keychain, macOS-only) and a **web** build (React + Vite, `localStorage`). Only the **web version** is runnable in the Linux Cloud environment, so the environment was verified against the web scope.

### Changes
- Add `AGENTS.md` with a `## Cursor Cloud specific instructions` section capturing:
  - Runnable scope (web only on Linux; Electron desktop is macOS-only).
  - The key gotcha: `NODE_ENV=production` is set in the environment, so plain `npm install` omits devDependencies — dependencies must be installed with `npm install --include=dev`.
  - `localStorage` fallback behavior and Electron-only UI actions.

### Environment / update script
- Update script: `npm install --include=dev` (forces dev deps despite `NODE_ENV=production`).

### Verification (web scope)
- ✅ `npm install --include=dev` — 516 packages added.
- ✅ `npm run check` — `tsc --noEmit` + ESLint clean.
- ✅ `npm run build:web` — production build into `dist-web/`.
- ✅ `npm run dev:web` — Vite dev server on `http://localhost:5173` (HTTP 200).
- ✅ Hello-world: added an OpenAI API key in the UI, saw Total Keys go 0→1, confirmed persistence after reload (localStorage), and verified search filtering.

[api_key_manager_web_demo.mp4](https://cursor.com/agents/bc-c734f968-4423-466e-b52a-26949fa84abe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapi_key_manager_web_demo.mp4)

[Key persisted after reload](https://cursor.com/agents/bc-c734f968-4423-466e-b52a-26949fa84abe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkey_persisted_after_reload.webp)

Out of scope: the macOS Electron desktop build (`npm run dev` / `npm run dist:mac`) cannot run on Linux.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c734f968-4423-466e-b52a-26949fa84abe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c734f968-4423-466e-b52a-26949fa84abe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

